### PR TITLE
[DI-304] Fix search for template usage

### DIFF
--- a/temple/ls.py
+++ b/temple/ls.py
@@ -106,7 +106,7 @@ def ls(github_user, template=None):
 
     if template:
         temple.check.is_git_ssh_path(template)
-        search_q = 'user:{} {} in:path "{}" in:file'.format(
+        search_q = 'user:{} filename:{} {}'.format(
             github_user,
             temple.constants.TEMPLE_CONFIG_FILE,
             template)

--- a/temple/tests/test_ls.py
+++ b/temple/tests/test_ls.py
@@ -107,7 +107,7 @@ def test_code_search_invalid_github_user(mocker, responses):
 
 @pytest.mark.parametrize('template, github_query', [
     (None, 'user:u cookiecutter.json in:path'),
-    ('git@github.com:u/t.git', 'user:u temple.yaml in:path "git@github.com:u/t.git" in:file'),
+    ('git@github.com:u/t.git', 'user:u filename:temple.yaml git@github.com:u/t.git'),
 ])
 def test_ls(template, github_query, mocker):
     mock_code_search = mocker.patch('temple.ls._code_search', autospec=True, return_value={


### PR DESCRIPTION
The "temple ls user template" usage seemed to be broken, it would return incomplete, inconsistent, or non-existent results.

I found that using the `filename:` term I could search within an explicitly named file instead of combining the `in:path` and `in:file` directives to try to do the same thing. I also found that including double-quotes in the query string made it less reliable, and according to the search documentation they are ignored anyway (see https://help.github.com/en/articles/searching-code#considerations-for-code-search).

I removed the double-quotes from the query string and switched to using the `filename:` search and results of my local testing have been reliable and (apparently) complete.