### PR TITLE
Bound pip < 19.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ deactivate_pyenv:
 # Builds all dependencies for a project
 .PHONY: dependencies
 dependencies:
+	${PIP_INSTALL_CMD} -U 'pip<19.2'
 	${PIP_INSTALL_CMD} -U -r dev_requirements.txt  # Use -U to ensure requirements are upgraded every time
 	${PIP_INSTALL_CMD} -r test_requirements.txt
 	${PIP_LOCAL_INSTALL_CMD}


### PR DESCRIPTION
[We are having issues compiling requirements in clinical-data-service](https://cloverhealth.slack.com/archives/C5ZLCJF54/p1566511189348900) this is due to an [issue with pip](https://github.com/jazzband/pip-tools/issues/853). The temporary solution seems to be to pin pip below 19.2.