### PR TITLE
Fix temple ls command's template param

### DIFF
--- a/temple/check.py
+++ b/temple/check.py
@@ -1,5 +1,6 @@
 """Utilities for performing checks and throwing useful error messages"""
 import os
+import re
 import subprocess
 
 import temple.constants
@@ -16,6 +17,11 @@ def is_git_ssh_path(template_path):
     if not template_path.startswith('git@github.com:') or not template_path.endswith('.git'):
         raise temple.exceptions.InvalidTemplatePathError(
             'The template path must be a git SSH url (e.g. "git@github.com:user/template.git")')
+
+
+def get_name_from_ssh_path(template_path):
+    matches = re.search(r"\/([^/]+)\.git$", template_path)
+    return matches[1]
 
 
 def _in_git_repo():

--- a/temple/check.py
+++ b/temple/check.py
@@ -21,7 +21,7 @@ def is_git_ssh_path(template_path):
 
 def get_name_from_ssh_path(template_path):
     matches = re.search(r"\/([^/]+)\.git$", template_path)
-    return matches[1]
+    return matches.group(1)
 
 
 def _in_git_repo():

--- a/temple/ls.py
+++ b/temple/ls.py
@@ -106,10 +106,11 @@ def ls(github_user, template=None):
 
     if template:
         temple.check.is_git_ssh_path(template)
+        template_repo_name = temple.check.get_name_from_ssh_path(template)
         search_q = 'user:{} filename:{} {}'.format(
             github_user,
             temple.constants.TEMPLE_CONFIG_FILE,
-            template)
+            template_repo_name)
     else:
         search_q = 'user:{} cookiecutter.json in:path'.format(github_user)
 

--- a/temple/tests/test_check.py
+++ b/temple/tests/test_check.py
@@ -13,6 +13,12 @@ def test_is_git_ssh_path_valid():
     temple.check.is_git_ssh_path('git@github.com:user/template.git')
 
 
+def test_get_name_from_ssh_path():
+    assert temple.check.get_name_from_ssh_path('git@github.com:user/template.git') == "template"
+    assert temple.check.get_name_from_ssh_path('git@github.com:user/foo-bar.git') == "foo-bar"
+    assert temple.check.get_name_from_ssh_path('git@github.com:user/foo_bar1.git') == "foo_bar1"
+
+
 @pytest.mark.parametrize('invalid_template_path', [
     'bad_path',
     'git@github.com:user/template',

--- a/temple/tests/test_ls.py
+++ b/temple/tests/test_ls.py
@@ -6,8 +6,7 @@ import pytest
 import requests
 
 import temple.exceptions
-from temple import constants
-from temple import ls
+from temple import constants, ls
 
 
 @pytest.mark.parametrize('headers, expected_links', [
@@ -107,7 +106,7 @@ def test_code_search_invalid_github_user(mocker, responses):
 
 @pytest.mark.parametrize('template, github_query', [
     (None, 'user:u cookiecutter.json in:path'),
-    ('git@github.com:u/t.git', 'user:u filename:temple.yaml git@github.com:u/t.git'),
+    ('git@github.com:u/t.git', 'user:u filename:temple.yaml t'),
 ])
 def test_ls(template, github_query, mocker):
     mock_code_search = mocker.patch('temple.ls._code_search', autospec=True, return_value={


### PR DESCRIPTION
At some point, GitHub's search changed, such that the `temple ls` command would always return empty results when passed the template param. If we strip this down to just the repo name things start working again as expected.

I tested this against an edge case where you may have templates with an overlapping prefix, and incorrect results were _not_ observed. In this mocked up example I was concerned that a search for `temple-foo` may also return `temple-foo-bar` templates, but it did not:

```sh
$ temple ls cloverhealth git@github.com:CloverHealth/temple-foo.git
git@github.com:CloverHealth/repo1.git
git@github.com:CloverHealth/repo2.git

$ temple ls cloverhealth git@github.com:CloverHealth/temple-foo-bar.git
git@github.com:CloverHealth/repo3.git
```

