### PR TITLE
support https as well as ssh repositories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -315,3 +315,5 @@ tags
 
 
 # End of https://www.gitignore.io/api/python,sublimetext,vim,emacs,git,pycharm,macos,visualstudiocode
+
+.idea/

--- a/temple/cli.py
+++ b/temple/cli.py
@@ -35,7 +35,7 @@ def main(ctx, version):
               help='Git SHA or branch of template to use for creation')
 def setup(template, version):
     """
-    Setup new project. Takes a full git SSH path to the template as returned
+    Setup new project. Takes a git path to the template as returned
     by "temple ls". In order to start a project from a
     particular version (instead of the latest), use the "-v" option.
     """

--- a/temple/setup.py
+++ b/temple/setup.py
@@ -53,11 +53,10 @@ def setup(template, version=None):
     of this function.
 
     Args:
-        template (str): The git SSH path to a template
+        template (str): The git path to a template
         version (str, optional): The version of the template to use when updating. Defaults
             to the latest version
     """
-    temple.check.is_git_ssh_path(template)
     temple.check.not_in_git_repo()
 
     repo_path = temple.utils.get_repo_path(template)

--- a/temple/update.py
+++ b/temple/update.py
@@ -38,7 +38,7 @@ def _cookiecutter_configs_have_changed(template, old_version, new_version):
         repo_dir = cc_vcs.clone(template, old_version, clone_dir)
         old_config = json.load(open(os.path.join(repo_dir, 'cookiecutter.json')))
         subprocess.check_call(
-            f'git checkout {new_version}', cwd=repo_dir, shell=True, stderr=subprocess.PIPE)
+            'git checkout %s' % new_version, cwd=repo_dir, shell=True, stderr=subprocess.PIPE)
         new_config = json.load(open(os.path.join(repo_dir, 'cookiecutter.json')))
 
     return old_config != new_config

--- a/temple/update.py
+++ b/temple/update.py
@@ -4,6 +4,7 @@ temple.update
 
 Updates a temple project with the latest template
 """
+import json
 import os
 import shutil
 import subprocess
@@ -11,6 +12,7 @@ import tempfile
 import textwrap
 
 import cookiecutter.main as cc_main
+import cookiecutter.vcs as cc_vcs
 import requests
 
 import temple.check
@@ -25,27 +27,24 @@ def _cookiecutter_configs_have_changed(template, old_version, new_version):
     new context
 
     Args:
-        template (str): The git SSH path to the template
+        template (str): The git path to the template
         old_version (str): The git SHA of the old version
         new_version (str): The git SHA of the new version
 
     Returns:
         bool: True if the cookiecutter.json files have been changed in the old and new versions
     """
-    temple.check.is_git_ssh_path(template)
-    repo_path = temple.utils.get_repo_path(template)
-    github_client = temple.utils.GithubClient()
-    api = '/repos/{}/contents/cookiecutter.json'.format(repo_path)
+    with tempfile.TemporaryDirectory() as clone_dir:
+        repo_dir = cc_vcs.clone(template, old_version, clone_dir)
+        old_config = json.load(open(os.path.join(repo_dir, 'cookiecutter.json')))
+        subprocess.check_call(
+            f'git checkout {new_version}', cwd=repo_dir, shell=True, stderr=subprocess.PIPE)
+        new_config = json.load(open(os.path.join(repo_dir, 'cookiecutter.json')))
 
-    old_config_resp = github_client.get(api, params={'ref': old_version})
-    old_config_resp.raise_for_status()
-    new_config_resp = github_client.get(api, params={'ref': new_version})
-    new_config_resp.raise_for_status()
-
-    return old_config_resp.json()['content'] != new_config_resp.json()['content']
+    return old_config != new_config
 
 
-def _get_latest_template_version_w_git_ssh(template):
+def _get_latest_template_version_w_git(template):
     """
     Tries to obtain the latest template version using an SSH key
     """
@@ -60,7 +59,7 @@ def _get_latest_template_version_w_git_ssh(template):
     return stdout
 
 
-def _get_latest_template_version_w_git_api(template):
+def _get_latest_template_version_w_github(template):
     """Tries to obtain the latest template version with the Github API"""
     temple.check.has_env_vars(temple.constants.GITHUB_API_TOKEN_ENV_VAR)
 
@@ -83,10 +82,10 @@ def _get_latest_template_version(template):
         str: The latest template version
     """
     try:
-        latest_version = _get_latest_template_version_w_git_ssh(template)
+        latest_version = _get_latest_template_version_w_git(template)
     except (subprocess.CalledProcessError, RuntimeError):
         try:
-            latest_version = _get_latest_template_version_w_git_api(template)
+            latest_version = _get_latest_template_version_w_github(template)
         except (requests.exceptions.RequestException,
                 temple.exceptions.InvalidEnvironmentError) as exc:
             raise temple.exceptions.CheckRunError((


### PR DESCRIPTION
Hi @pauljz 

I would like to use temple with repositories over HTTP as opposed to SSH. This change makes that work for `temple setup` and `temple update`. Since it delegates to cookiecutter, it might actually support local folders and other [cookiecutter styles](https://github.com/cookiecutter/cookiecutter#features). 

This also removes the dependency on GitHub for those commands. However it does not change `temple ls` which would be broader in scope.